### PR TITLE
Add Rust HTTP constants

### DIFF
--- a/contents/codes/100.md
+++ b/contents/codes/100.md
@@ -3,6 +3,7 @@ set: 1
 code: 100
 title: Continue
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::CONTINUE"
     "Rails HTTP Status Symbol": ":continue"
     "Go HTTP Status Constant": "http.StatusContinue"
     "Symfony HTTP Status Constant": "Response::HTTP_CONTINUE"

--- a/contents/codes/101.md
+++ b/contents/codes/101.md
@@ -3,6 +3,7 @@ set: 1
 code: 101
 title: Switching Protocols
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::SWITCHING_PROTOCOLS"
     "Rails HTTP Status Symbol": ":switching_protocols"
     "Go HTTP Status Constant": "http.StatusSwitchingProtocols"
     "Symfony HTTP Status Constant": "Response::HTTP_SWITCHING_PROTOCOLS"

--- a/contents/codes/102.md
+++ b/contents/codes/102.md
@@ -3,6 +3,7 @@ set: 1
 code: 102
 title: Processing
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PROCESSING"
     "Rails HTTP Status Symbol": ":processing"
     "Symfony HTTP Status Constant": "Response::HTTP_PROCESSING"
 ---

--- a/contents/codes/200.md
+++ b/contents/codes/200.md
@@ -3,6 +3,7 @@ set: 2
 code: 200
 title: OK
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::OK"
     "Rails HTTP Status Symbol": ":ok"
     "Go HTTP Status Constant": "http.StatusOK"
     "Symfony HTTP Status Constant": "Response::HTTP_OK"

--- a/contents/codes/201.md
+++ b/contents/codes/201.md
@@ -3,6 +3,7 @@ set: 2
 code: 201
 title: Created
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::CREATED"
     "Rails HTTP Status Symbol": ":created"
     "Go HTTP Status Constant": "http.StatusCreated"
     "Symfony HTTP Status Constant": "Response::HTTP_CREATED"

--- a/contents/codes/202.md
+++ b/contents/codes/202.md
@@ -3,6 +3,7 @@ set: 2
 code: 202
 title: Accepted
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::ACCEPTED"
     "Rails HTTP Status Symbol": ":accepted"
     "Go HTTP Status Constant": "http.StatusAccepted"
     "Symfony HTTP Status Constant": "Response::HTTP_ACCEPTED"

--- a/contents/codes/203.md
+++ b/contents/codes/203.md
@@ -3,6 +3,7 @@ set: 2
 code: 203
 title: Non-authoritative Information
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NON_AUTHORITATIVE_INFORMATION"
     "Rails HTTP Status Symbol": ":non_authoritative_information"
     "Go HTTP Status Constant": "http.StatusNonAuthoritativeInfo"
     "Symfony HTTP Status Constant": "Response::HTTP_NON_AUTHORITATIVE_INFORMATION"

--- a/contents/codes/204.md
+++ b/contents/codes/204.md
@@ -3,6 +3,7 @@ set: 2
 code: 204
 title: No Content
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NO_CONTENT"
     "Rails HTTP Status Symbol": ":no_content"
     "Go HTTP Status Constant": "http.StatusNoContent"
     "Symfony HTTP Status Constant": "Response::HTTP_NO_CONTENT"

--- a/contents/codes/205.md
+++ b/contents/codes/205.md
@@ -3,6 +3,7 @@ set: 2
 code: 205
 title: Reset Content
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::RESET_CONTENT"
     "Rails HTTP Status Symbol": ":reset_content"
     "Go HTTP Status Constant": "http.StatusResetContent"
     "Symfony HTTP Status Constant": "Response::HTTP_RESET_CONTENT"

--- a/contents/codes/206.md
+++ b/contents/codes/206.md
@@ -3,6 +3,7 @@ set: 2
 code: 206
 title: Partial Content
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PARTIAL_CONTENT"
     "Rails HTTP Status Symbol": ":partial_content"
     "Go HTTP Status Constant": "http.StatusPartialContent"
     "Symfony HTTP Status Constant": "Response::HTTP_PARTIAL_CONTENT"

--- a/contents/codes/207.md
+++ b/contents/codes/207.md
@@ -3,6 +3,7 @@ set: 2
 code: 207
 title: Multi-Status
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::MULTI_STATUS"
     "Rails HTTP Status Symbol": ":multi_status"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTI_STATUS"
 ---

--- a/contents/codes/208.md
+++ b/contents/codes/208.md
@@ -3,6 +3,7 @@ set: 2
 code: 208
 title: Already Reported
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::ALREADY_REPORTED"
     "Symfony HTTP Status Constant": "Response::HTTP_ALREADY_REPORTED"
 ---
 

--- a/contents/codes/226.md
+++ b/contents/codes/226.md
@@ -3,6 +3,7 @@ set: 2
 code: 226
 title: IM Used
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::IM_USED"
     "Rails HTTP Status Symbol": ":im_used"
     "Symfony HTTP Status Constant": "Response::HTTP_IM_USED"
 ---

--- a/contents/codes/300.md
+++ b/contents/codes/300.md
@@ -3,6 +3,7 @@ set: 3
 code: 300
 title: Multiple Choices
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::MULTIPLE_CHOICES"
     "Rails HTTP Status Symbol": ":multiple_choices"
     "Go HTTP Status Constant": "http.StatusMultipleChoices"
     "Symfony HTTP Status Constant": "Response::HTTP_MULTIPLE_CHOICES"

--- a/contents/codes/301.md
+++ b/contents/codes/301.md
@@ -3,6 +3,7 @@ set: 3
 code: 301
 title: Moved Permanently
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::MOVED_PERMANENTLY"
     "Rails HTTP Status Symbol": ":moved_permanently"
     "Go HTTP Status Constant": "http.StatusMovedPermanently"
     "Symfony HTTP Status Constant": "Response::HTTP_MOVED_PERMANENTLY"

--- a/contents/codes/302.md
+++ b/contents/codes/302.md
@@ -3,6 +3,7 @@ set: 3
 code: 302
 title: Found
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::FOUND"
     "Rails HTTP Status Symbol": ":found"
     "Go HTTP Status Constant": "http.StatusFound"
     "Symfony HTTP Status Constant": "Response::HTTP_FOUND"

--- a/contents/codes/303.md
+++ b/contents/codes/303.md
@@ -3,6 +3,7 @@ set: 3
 code: 303
 title: See Other
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::SEE_OTHER"
     "Rails HTTP Status Symbol": ":see_other"
     "Go HTTP Status Constant": "http.StatusSeeOther"
     "Symfony HTTP Status Constant": "Response::HTTP_SEE_OTHER"

--- a/contents/codes/304.md
+++ b/contents/codes/304.md
@@ -3,6 +3,7 @@ set: 3
 code: 304
 title: Not Modified
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NOT_MODIFIED"
     "Rails HTTP Status Symbol": ":not_modified"
     "Go HTTP Status Constant": "http.StatusNotModified"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_MODIFIED"

--- a/contents/codes/305.md
+++ b/contents/codes/305.md
@@ -3,6 +3,7 @@ set: 3
 code: 305
 title: Use Proxy
 #references:
+    "Rust HTTP Status Constant": "http::StatusCode::USE_PROXY"
 #   "Rails HTTP Status Symbol": "use_proxy"
 #   "Go HTTP Status Constant": "http.StatusUseProxy"
 #   "Symfony HTTP Status Constant": "Response::HTTP_USE_PROXY"

--- a/contents/codes/307.md
+++ b/contents/codes/307.md
@@ -3,6 +3,7 @@ set: 3
 code: 307
 title: Temporary Redirect
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::TEMPORARY_REDIRECT"
     "Rails HTTP Status Symbol": ":temporary_redirect"
     "Go HTTP Status Constant": "http.StatusTemporaryRedirect"
     "Symfony HTTP Status Constant": "Response::HTTP_TEMPORARY_REDIRECT"

--- a/contents/codes/308.md
+++ b/contents/codes/308.md
@@ -3,6 +3,7 @@ set: 3
 code: 308
 title: Permanent Redirect
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PERMANENT_REDIRECT"
     "Symfony HTTP Status Constant": "Response::HTTP_PERMANENTLY_REDIRECT"
 ---
 

--- a/contents/codes/400.md
+++ b/contents/codes/400.md
@@ -3,6 +3,7 @@ set: 4
 code: 400
 title: Bad Request
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::BAD_REQUEST"
     "Rails HTTP Status Symbol": "bad_request"
     "Go HTTP Status Constant": "http.StatusBadRequest"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_REQUEST"

--- a/contents/codes/401.md
+++ b/contents/codes/401.md
@@ -3,6 +3,7 @@ set: 4
 code: 401
 title: Unauthorized
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::UNAUTHORIZED"
     "Rails HTTP Status Symbol": ":unauthorized"
     "Go HTTP Status Constant": "http.StatusUnauthorized"
     "Symfony HTTP Status Constant": "Response::HTTP_UNAUTHORIZED"

--- a/contents/codes/402.md
+++ b/contents/codes/402.md
@@ -3,6 +3,7 @@ set: 4
 code: 402
 title: Payment Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PAYMENT_REQUIRED"
     "Rails HTTP Status Symbol": ":payment_required"
     "Go HTTP Status Constant": "http.StatusPaymentRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PAYMENT_REQUIRED"

--- a/contents/codes/403.md
+++ b/contents/codes/403.md
@@ -3,6 +3,7 @@ set: 4
 code: 403
 title: Forbidden
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::FORBIDDEN"
     "Rails HTTP Status Symbol": ":forbidden"
     "Go HTTP Status Constant": "http.StatusForbidden"
     "Symfony HTTP Status Constant": "Response::HTTP_FORBIDDEN"

--- a/contents/codes/404.md
+++ b/contents/codes/404.md
@@ -3,6 +3,7 @@ set: 4
 code: 404
 title: Not Found
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NOT_FOUND"
     "Rails HTTP Status Symbol": ":not_found"
     "Go HTTP Status Constant": "http.StatusNotFound"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_FOUND"

--- a/contents/codes/405.md
+++ b/contents/codes/405.md
@@ -3,6 +3,7 @@ set: 4
 code: 405
 title: Method Not Allowed
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::METHOD_NOT_ALLOWED"
     "Rails HTTP Status Symbol": ":method_not_allowed"
     "Go HTTP Status Constant": "http.StatusMethodNotAllowed"
     "Symfony HTTP Status Constant": "Response::HTTP_METHOD_NOT_ALLOWED"

--- a/contents/codes/406.md
+++ b/contents/codes/406.md
@@ -3,6 +3,7 @@ set: 4
 code: 406
 title: Not Acceptable
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NOT_ACCEPTABLE"
     "Rails HTTP Status Symbol": ":not_acceptable"
     "Go HTTP Status Constant": "http.StatusNotAcceptable"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_ACCEPTABLE"

--- a/contents/codes/407.md
+++ b/contents/codes/407.md
@@ -3,6 +3,7 @@ set: 4
 code: 407
 title: Proxy Authentication Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PROXY_AUTHENTICATION_REQUIRED"
     "Rails HTTP Status Symbol": ":proxy_authentication_required"
     "Go HTTP Status Constant": "http.StatusProxyAuthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_PROXY_AUTHENTICATION_REQUIRED"

--- a/contents/codes/408.md
+++ b/contents/codes/408.md
@@ -3,6 +3,7 @@ set: 4
 code: 408
 title: Request Timeout
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::REQUEST_TIMEOUT"
     "Rails HTTP Status Symbol": ":request_timeout"
     "Go HTTP Status Constant": "http.StatusRequestTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_TIMEOUT"

--- a/contents/codes/409.md
+++ b/contents/codes/409.md
@@ -3,6 +3,7 @@ set: 4
 code: 409
 title: Conflict
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::CONFLICT"
     "Rails HTTP Status Symbol": ":conflict"
     "Go HTTP Status Constant": "http.StatusConflict"
     "Symfony HTTP Status Constant": "Response::HTTP_CONFLICT"

--- a/contents/codes/410.md
+++ b/contents/codes/410.md
@@ -3,6 +3,7 @@ set: 4
 code: 410
 title: Gone
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::GONE"
     "Rails HTTP Status Symbol": ":gone"
     "Go HTTP Status Constant": "http.StatusGone"
     "Symfony HTTP Status Constant": "Response::HTTP_GONE"

--- a/contents/codes/411.md
+++ b/contents/codes/411.md
@@ -3,6 +3,7 @@ set: 4
 code: 411
 title: Length Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::LENGTH_REQUIRED"
     "Rails HTTP Status Symbol": ":length_required"
     "Go HTTP Status Constant": "http.StatusLengthRequired"
     "Symfony HTTP Status Constant": "Response::HTTP_LENGTH_REQUIRED"

--- a/contents/codes/412.md
+++ b/contents/codes/412.md
@@ -3,6 +3,7 @@ set: 4
 code: 412
 title: Precondition Failed
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PRECONDITION_FAILED"
     "Rails HTTP Status Symbol": ":precondition_failed"
     "Go HTTP Status Constant": "http.StatusPreconditionFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_FAILED"

--- a/contents/codes/413.md
+++ b/contents/codes/413.md
@@ -3,6 +3,7 @@ set: 4
 code: 413
 title: Payload Too Large
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PAYLOAD_TOO_LARGE"
     "Rails HTTP Status Symbol": ":request_entity_too_large"
     "Go HTTP Status Constant": "http.StatusRequestEntityTooLarge"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_ENTITY_TOO_LARGE"

--- a/contents/codes/414.md
+++ b/contents/codes/414.md
@@ -3,6 +3,7 @@ set: 4
 code: 414
 title: Request-URI Too Long
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::URI_TOO_LONG"
     "Rails HTTP Status Symbol": ":request_uri_too_long"
     "Go HTTP Status Constant": "http.StatusRequestURITooLong"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_URI_TOO_LONG"

--- a/contents/codes/415.md
+++ b/contents/codes/415.md
@@ -3,6 +3,7 @@ set: 4
 code: 415
 title: Unsupported Media Type
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::UNSUPPORTED_MEDIA_TYPE"
     "Rails HTTP Status Symbol": ":unsupported_media_type"
     "Go HTTP Status Constant": "http.StatusUnsupportedMediaType"
     "Symfony HTTP Status Constant": "Response::HTTP_UNSUPPORTED_MEDIA_TYPE"

--- a/contents/codes/416.md
+++ b/contents/codes/416.md
@@ -3,6 +3,7 @@ set: 4
 code: 416
 title: Requested Range Not Satisfiable
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::RANGE_NOT_SATISFIABLE"
     "Rails HTTP Status Symbol": ":requested_range_not_satisfiable"
     "Go HTTP Status Constant": "http.StatusRequestedRangeNotSatisfiable"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUESTED_RANGE_NOT_SATISFIABLE"

--- a/contents/codes/417.md
+++ b/contents/codes/417.md
@@ -3,6 +3,7 @@ set: 4
 code: 417
 title: Expectation Failed
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::EXPECTATION_FAILED"
     "Rails HTTP Status Symbol": ":expectation_failed"
     "Go HTTP Status Constant": "http.StatusExpectationFailed"
     "Symfony HTTP Status Constant": "Response::HTTP_EXPECTATION_FAILED"

--- a/contents/codes/418.md
+++ b/contents/codes/418.md
@@ -3,6 +3,7 @@ set: 4
 code: 418
 title: I'm a teapot
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::IM_A_TEAPOT"
     "Go HTTP Status Constant": "http.StatusTeapot"
     "Symfony HTTP Status Constant": "Response::HTTP_I_AM_A_TEAPOT"
 ---

--- a/contents/codes/421.md
+++ b/contents/codes/421.md
@@ -3,6 +3,7 @@ set: 4
 code: 421
 title: Misdirected Request
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::MISDIRECTED_REQUEST"
     "Rails HTTP Status Symbol": ":misdirected_request"
 ---
 

--- a/contents/codes/422.md
+++ b/contents/codes/422.md
@@ -3,6 +3,7 @@ set: 4
 code: 422
 title: Unprocessable Entity
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::UNPROCESSABLE_ENTITY"
     "Rails HTTP Status Symbol": ":unprocessable_entity"
     "Symfony HTTP Status Constant": "Response::HTTP_UNPROCESSABLE_ENTITY"
 ---

--- a/contents/codes/423.md
+++ b/contents/codes/423.md
@@ -3,6 +3,7 @@ set: 4
 code: 423
 title: Locked
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::LOCKED"
     "Rails HTTP Status Symbol": ":locked"
     "Symfony HTTP Status Constant": "Response::HTTP_LOCKED"
 ---

--- a/contents/codes/424.md
+++ b/contents/codes/424.md
@@ -3,6 +3,7 @@ set: 4
 code: 424
 title: Failed Dependency
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::FAILED_DEPENDENCY"
     "Rails HTTP Status Symbol": "failed_dependency"
     "Symfony HTTP Status Constant": "Response::HTTP_FAILED_DEPENDENCY"
     "Python HTTP Status Constant": "httplib.FAILED_DEPENDENCY"

--- a/contents/codes/426.md
+++ b/contents/codes/426.md
@@ -3,6 +3,7 @@ set: 4
 code: 426
 title: Upgrade Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::UPGRADE_REQUIRED"
     "Rails HTTP Status Symbol": ":upgrade_required"
     "Symfony HTTP Status Constant": "Response::HTTP_UPGRADE_REQUIRED"
 ---

--- a/contents/codes/428.md
+++ b/contents/codes/428.md
@@ -3,6 +3,7 @@ set: 4
 code: 428
 title: Precondition Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::PRECONDITION_REQUIRED"
     "Symfony HTTP Status Constant": "Response::HTTP_PRECONDITION_REQUIRED"
 ---
 

--- a/contents/codes/429.md
+++ b/contents/codes/429.md
@@ -3,6 +3,7 @@ set: 4
 code: 429
 title: Too Many Requests
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::TOO_MANY_REQUESTS"
     "Symfony HTTP Status Constant": "Response::HTTP_TOO_MANY_REQUESTS"
 ---
 

--- a/contents/codes/431.md
+++ b/contents/codes/431.md
@@ -3,6 +3,7 @@ set: 4
 code: 431
 title: Request Header Fields Too Large
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::REQUEST_HEADER_FIELDS_TOO_LARGE"
     "Symfony HTTP Status Constant": "Response::HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE"
 ---
 

--- a/contents/codes/451.md
+++ b/contents/codes/451.md
@@ -4,6 +4,7 @@ code: 451
 title: Unavailable For Legal Reasons
 proposal: true
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS"
     "Symfony HTTP Status Constant": "Response::HTTP_UNAVAILABLE_FOR_LEGAL_REASONS"
 ---
 

--- a/contents/codes/500.md
+++ b/contents/codes/500.md
@@ -3,6 +3,7 @@ set: 5
 code: 500
 title: Internal Server Error
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::INTERNAL_SERVER_ERROR"
     "Rails HTTP Status Symbol": ":internal_server_error"
     "Go HTTP Status Constant": "http.StatusInternalServerError"
     "Symfony HTTP Status Constant": "Response::HTTP_INTERNAL_SERVER_ERROR"

--- a/contents/codes/501.md
+++ b/contents/codes/501.md
@@ -3,6 +3,7 @@ set: 5
 code: 501
 title: Not Implemented
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NOT_IMPLEMENTED"
     "Rails HTTP Status Symbol": ":not_implemented"
     "Go HTTP Status Constant": "http.StatusNotImplemented"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_IMPLEMENTED"

--- a/contents/codes/502.md
+++ b/contents/codes/502.md
@@ -3,6 +3,7 @@ set: 5
 code: 502
 title: Bad Gateway
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::BAD_GATEWAY"
     "Rails HTTP Status Symbol": ":bad_gateway"
     "Go HTTP Status Constant": "http.StatusBadGateway"
     "Symfony HTTP Status Constant": "Response::HTTP_BAD_GATEWAY"

--- a/contents/codes/503.md
+++ b/contents/codes/503.md
@@ -3,6 +3,7 @@ set: 5
 code: 503
 title: Service Unavailable
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::SERVICE_UNAVAILABLE"
     "Rails HTTP Status Symbol": ":service_unavailable"
     "Go HTTP Status Constant": "http.StatusServiceUnavailable"
     "Symfony HTTP Status Constant": "Response::HTTP_SERVICE_UNAVAILABLE"

--- a/contents/codes/504.md
+++ b/contents/codes/504.md
@@ -3,6 +3,7 @@ set: 5
 code: 504
 title: Gateway Timeout
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::GATEWAY_TIMEOUT"
     "Rails HTTP Status Symbol": ":gateway_timeout"
     "Go HTTP Status Constant": "http.StatusGatewayTimeout"
     "Symfony HTTP Status Constant": "Response::HTTP_GATEWAY_TIMEOUT"

--- a/contents/codes/505.md
+++ b/contents/codes/505.md
@@ -3,6 +3,7 @@ set: 5
 code: 505
 title: HTTP Version Not Supported
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::HTTP_VERSION_NOT_SUPPORTED"
     "Rails HTTP Status Symbol": ":http_version_not_supported"
     "Go HTTP Status Constant": "http.StatusHTTPVersionNotSupported"
     "Symfony HTTP Status Constant": "Response::HTTP_VERSION_NOT_SUPPORTED"

--- a/contents/codes/506.md
+++ b/contents/codes/506.md
@@ -3,6 +3,7 @@ set: 5
 code: 506
 title: Variant Also Negotiates
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::VARIANT_ALSO_NEGOTIATES"
     "Symfony HTTP Status Constant": "Response::HTTP_VARIANT_ALSO_NEGOTIATES_EXPERIMENTAL"
 ---
 

--- a/contents/codes/507.md
+++ b/contents/codes/507.md
@@ -3,6 +3,7 @@ set: 5
 code: 507
 title: Insufficient Storage
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::INSUFFICIENT_STORAGE"
     "Rails HTTP Status Symbol": ":insufficient_storage"
     "Symfony HTTP Status Constant": "Response::HTTP_INSUFFICIENT_STORAGE"
 ---

--- a/contents/codes/508.md
+++ b/contents/codes/508.md
@@ -3,6 +3,7 @@ set: 5
 code: 508
 title: Loop Detected
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::LOOP_DETECTED"
     "Symfony HTTP Status Constant": "Response::HTTP_LOOP_DETECTED"
 ---
 

--- a/contents/codes/510.md
+++ b/contents/codes/510.md
@@ -3,6 +3,7 @@ set: 5
 code: 510
 title: Not Extended
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NOT_EXTENDED"
     "Rails HTTP Status Symbol": ":not_extended"
     "Symfony HTTP Status Constant": "Response::HTTP_NOT_EXTENDED"
 ---

--- a/contents/codes/511.md
+++ b/contents/codes/511.md
@@ -3,6 +3,7 @@ set: 5
 code: 511
 title: Network Authentication Required
 references:
+    "Rust HTTP Status Constant": "http::StatusCode::NETWORK_AUTHENTICATION_REQUIRED"
     "Symfony HTTP Status Constant": "Response::HTTP_NETWORK_AUTHENTICATION_REQUIRED"
 ---
 


### PR DESCRIPTION
In case I need to do this again.

I created a file of status code to constant names, then ran this script
against it:

```
IFS=$'\n';
for i in $(cat rust-consts.txt); do
  code="$(echo $i | awk '{print $1}')"
  const="http::StatusCode::$(echo $i | awk '{print $2}')"
  fastmod "(references:)(\n)" "\${1}\${2}    \"Rust HTTP Status Constant\": \"${const}\"\${2}" "contents/codes/${code}.md"
done
```

The highlight is the grossness for the fastmod invocation, since I
couldn't figure out how to get fastmod to add newlines in the
replacement text, so I captured and reused the one from the searched
patterns.

Same as https://github.com/rmaake1/httpstatuses/pull/72